### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,12 +17,13 @@ TypeScript API.
 Prerequisites:
 
 * [Make](https://www.gnu.org/software/make/) — used for executing the make target
-* [WASI SDK](https://github.com/WebAssembly/wasi-sdk), [Rust](https://www.rust-lang.org/tools/install), and [`cargo component`](https://github.com/bytecodealliance/cargo-component)  — used for compiling the Wasm component used for compression
+* [WASI SDK](https://github.com/WebAssembly/wasi-sdk), [Rust](https://www.rust-lang.org/tools/install), [wasmtime](https://wasmtime.dev/) and [`cargo component`](https://github.com/bytecodealliance/cargo-component)  — used for compiling the Wasm component used for compression
+* After installing cargo, add the nightly target: `rustup update nightly`
 * [Node.js](https://nodejs.org/en) and [NPM](https://www.npmjs.com/) — used for building the TypeScript API into a Wasm component
 * [Spin](https://github.com/fermyon/spin) — used for running the overall function
 
 ```
-# set the WASI_SDK variable to your installation directory
+# set the WASI_SDK variable inside the Makefile to your installation directory
 $ make
 $ spin up
 Logging component stdio to ".spin/logs/"


### PR DESCRIPTION
Small updates with extra steps that were needed for a clean install.

E.g., I got `toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed` which is fixed by `rustup update nightly`.

Then I got:

```
error: failed to find `wasmtime` specified by either the `CARGO_TARGET_WASM32_WASIP1_RUNNER`environment variable or as the `wasm32-wasip1` runner in `.cargo/config.toml`
```

Which was fixed by installing wasmtime the default way (`curl https://wasmtime.dev/install.sh -sSf | bash`)